### PR TITLE
add ai summary button to each metaG result section

### DIFF
--- a/webapp/client/src/workflows/metagenomics/pipeline/results/MetaG.js
+++ b/webapp/client/src/workflows/metagenomics/pipeline/results/MetaG.js
@@ -7,7 +7,22 @@ import { Taxonomy } from '../../results/Taxonomy'
 import { Phylogeny } from '../../results/Phylogeny'
 import { RefBased } from '../../results/RefBased'
 import { GeneFamily } from '../../results/GeneFamily'
-import { workflows } from '../../defaults'
+import { workflowList } from 'src/util'
+
+const resultTitles = {
+  runFaQCs: 'ReadsQC Result',
+  assembly: 'Assembly Result',
+  annotation: 'Annotation Result',
+  binning: 'Binning Result',
+  antiSmash: 'AntiSmash Result',
+  taxonomy: 'Taxonomy Result',
+  phylogeny: 'Phylogeny Analysis Result',
+  refBased: 'Reference-Based Analysis Result',
+  geneFamily: 'Gene Family Result',
+}
+
+const getResultTitle = (workflow) =>
+  resultTitles[workflow] || `${workflowList[workflow]?.label || workflow} Result`
 
 export const MetaG = (props) => {
   return (
@@ -19,8 +34,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -31,8 +46,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -43,8 +58,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -55,8 +70,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -67,8 +82,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -79,8 +94,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -91,8 +106,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -103,8 +118,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />
@@ -115,8 +130,8 @@ export const MetaG = (props) => {
               key={index}
               result={props.result[workflow]}
               project={props.project}
-              title={workflows[workflow].title + ' Result'}
-              userType={props.type}
+              title={getResultTitle(workflow)}
+              userType={props.userType}
               allExpand={props.allExpand}
               allClosed={props.allClosed}
             />

--- a/webapp/client/src/workflows/metagenomics/results/Annotation.js
+++ b/webapp/client/src/workflows/metagenomics/results/Annotation.js
@@ -7,6 +7,7 @@ import config from 'src/config'
 export const Annotation = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Annotation Result'
 
   useEffect(() => {
     if (props.allExpand > 0) {
@@ -27,8 +28,14 @@ export const Annotation = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'Annotation Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'annotation',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/AntiSmash.js
+++ b/webapp/client/src/workflows/metagenomics/results/AntiSmash.js
@@ -7,6 +7,7 @@ import config from 'src/config'
 export const AntiSmash = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'AntiSmash Result'
 
   useEffect(() => {
     if (props.allExpand > 0) {
@@ -27,8 +28,14 @@ export const AntiSmash = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'AntiSmash Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'antiSmash',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/Assembly.js
+++ b/webapp/client/src/workflows/metagenomics/results/Assembly.js
@@ -7,6 +7,7 @@ import config from 'src/config'
 export const Assembly = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Assembly Result'
 
   useEffect(() => {
     if (props.allExpand > 0) {
@@ -27,8 +28,14 @@ export const Assembly = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'Assembly Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'assembly',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/Binning.js
+++ b/webapp/client/src/workflows/metagenomics/results/Binning.js
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from 'react'
 import { Card, CardBody, Collapse } from 'reactstrap'
 import { StatsTable } from 'src/edge/common/Tables'
 import { Header } from 'src/edge/project/results/CardHeader'
-import config from 'src/config'
 
 export const Binning = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
-  const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Binning Result'
 
   useEffect(() => {
     if (props.allExpand > 0) {
@@ -27,8 +26,14 @@ export const Binning = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'Binning Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'binning',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/GeneFamily.js
+++ b/webapp/client/src/workflows/metagenomics/results/GeneFamily.js
@@ -4,11 +4,10 @@ import { MaterialReactTable } from 'material-react-table'
 import { ThemeProvider } from '@mui/material'
 import { theme } from 'src/edge/um/common/tableUtil'
 import { Header } from 'src/edge/project/results/CardHeader'
-import config from 'src/config'
 
 export const GeneFamily = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
-  const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Gene Family Result'
   const summaryData = props.result.summary
   //create columns from data
   const summaryColumns = useMemo(
@@ -42,8 +41,14 @@ export const GeneFamily = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'Gene Family Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'geneFamily',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/Phylogeny.js
+++ b/webapp/client/src/workflows/metagenomics/results/Phylogeny.js
@@ -8,6 +8,7 @@ export const Phylogeny = (props) => {
   const [iframeKey, setIframeKey] = useState(0)
   const [iframeKey2, setIframeKey2] = useState(0)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Phylogeny Analysis Result'
 
   useEffect(() => {
     if (props.allExpand > 0) {
@@ -30,8 +31,14 @@ export const Phylogeny = (props) => {
           setIframeKey(iframeKey + 1) // Force re-render of iframes when toggling
           setIframeKey2(iframeKey2 + 1) // Force re-render of iframes when toggling
         }}
-        title={'Phylogeny Analysis Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'phylogeny',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/RefBased.js
+++ b/webapp/client/src/workflows/metagenomics/results/RefBased.js
@@ -9,6 +9,7 @@ import config from 'src/config'
 export const RefBased = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Reference-Based Analysis Result'
   const summaryData = props.result.summary
   const [coveragePlots, setCoveragePlots] = useState([])
   const snpsData = props.result.snps
@@ -104,8 +105,14 @@ export const RefBased = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'Reference-Based Analysis Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'refBased',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/RunFaQCs.js
+++ b/webapp/client/src/workflows/metagenomics/results/RunFaQCs.js
@@ -7,6 +7,7 @@ import config from 'src/config'
 export const RunFaQCs = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'ReadsQC Result'
 
   useEffect(() => {
     if (props.allExpand > 0) {
@@ -27,8 +28,14 @@ export const RunFaQCs = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'ReadsQC Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'runFaQCs',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>

--- a/webapp/client/src/workflows/metagenomics/results/Taxonomy.js
+++ b/webapp/client/src/workflows/metagenomics/results/Taxonomy.js
@@ -26,6 +26,7 @@ import { taxClassificationOptions } from '../defaults'
 export const Taxonomy = (props) => {
   const [collapseCard, setCollapseCard] = useState(true)
   const url = config.APP.BASE_URI + '/projects/' + props.project.code + '/'
+  const title = props.title || 'Taxonomy Result'
   const tabs = {
     Summary: 'table and krona',
     'Classification Tools': 'table and tree/krona',
@@ -135,8 +136,14 @@ export const Taxonomy = (props) => {
         toggleParms={() => {
           setCollapseCard(!collapseCard)
         }}
-        title={'Taxonomy Result'}
+        title={title}
         collapseParms={collapseCard}
+        aiSummary={{
+          sectionKey: 'taxonomy',
+          title,
+          project: props.project,
+          userType: props.userType,
+        }}
       />
       <Collapse isOpen={!collapseCard}>
         <CardBody>


### PR DESCRIPTION
This pull request refactors how result titles and user type information are handled and passed to metagenomics workflow result components. It centralizes title generation, ensures consistency across components, and adds an `aiSummary` prop to support future AI-driven features.

**Result Title and User Type Handling:**

- Centralized the logic for generating result titles into a `getResultTitle` function and updated all workflow result components to use this function, ensuring consistent naming and reducing duplication. (`MetaG.js`) [[1]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L10-R25) [[2]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L22-R38) [[3]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L34-R50) [[4]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L46-R62) [[5]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L58-R74) [[6]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L70-R86) [[7]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L82-R98) [[8]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L94-R110) [[9]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L106-R122) [[10]](diffhunk://#diff-d8c7f6603df3eca98101e377d439ef09b5e725c69d27872f410215123d2a9662L118-R134)
- Changed all result components to accept a `title` prop (defaulting to the appropriate result name) and to use `props.userType` instead of `props.type` for clarity and consistency. (`Annotation.js`, `AntiSmash.js`, `Assembly.js`, `Binning.js`, `GeneFamily.js`, `Phylogeny.js`, `RefBased.js`, `RunFaQCs.js`, `Taxonomy.js`) [[1]](diffhunk://#diff-bbe7a62f8f6d24087a576a90e706a6fec1e96a2f8150d560277a0a92f7cb775bR10) [[2]](diffhunk://#diff-bbe7a62f8f6d24087a576a90e706a6fec1e96a2f8150d560277a0a92f7cb775bL30-R38) [[3]](diffhunk://#diff-56dedd420b2cc3a314b670107ee8d26d4e3992b3e6d21d7c4910fffed51a5a34R10) [[4]](diffhunk://#diff-56dedd420b2cc3a314b670107ee8d26d4e3992b3e6d21d7c4910fffed51a5a34L30-R38) [[5]](diffhunk://#diff-63bcb6da08b56b7d9b0cb2461e95c06488252dd394e6eb697ee9de5b6993c87aR10) [[6]](diffhunk://#diff-63bcb6da08b56b7d9b0cb2461e95c06488252dd394e6eb697ee9de5b6993c87aL30-R38) [[7]](diffhunk://#diff-ac02c69f1c0ea9b6e24e74cb2fbd501eaed62ca60ede474c7c3b5da6404879c5L5-R8) [[8]](diffhunk://#diff-ac02c69f1c0ea9b6e24e74cb2fbd501eaed62ca60ede474c7c3b5da6404879c5L30-R36) [[9]](diffhunk://#diff-d05cc1b0a62190fe5221b30dd151a43177ceec0d8b38f831709f7263457ff6efL7-R10) [[10]](diffhunk://#diff-d05cc1b0a62190fe5221b30dd151a43177ceec0d8b38f831709f7263457ff6efL45-R51) [[11]](diffhunk://#diff-b7b78168e1b90bcef9bb3de0aa9dcdc73bbc6fd567a14a69160d2d5dc3f79e74R11) [[12]](diffhunk://#diff-b7b78168e1b90bcef9bb3de0aa9dcdc73bbc6fd567a14a69160d2d5dc3f79e74L33-R41) [[13]](diffhunk://#diff-cd816a420b07c0b785657a48ef79f47bb19d21751e5976aa3c7cae77c46e4d60R12) [[14]](diffhunk://#diff-cd816a420b07c0b785657a48ef79f47bb19d21751e5976aa3c7cae77c46e4d60L107-R115) [[15]](diffhunk://#diff-7798fc2bd1f5116316655e57829c85310037ec1e6326212e59270b47d87a0755R10) [[16]](diffhunk://#diff-7798fc2bd1f5116316655e57829c85310037ec1e6326212e59270b47d87a0755L30-R38) [[17]](diffhunk://#diff-8a7fe397191b05d073c233a7da99f4d6453af89a53a0b00e74028a745954c63eR29) [[18]](diffhunk://#diff-8a7fe397191b05d073c233a7da99f4d6453af89a53a0b00e74028a745954c63eL138-R146)

**AI Summary Prop Introduction:**

- Added an `aiSummary` prop to each result component, containing metadata such as `sectionKey`, `title`, `project`, and `userType`, to facilitate future AI-generated summaries or analyses. (`Annotation.js`, `AntiSmash.js`, `Assembly.js`, `Binning.js`, `GeneFamily.js`, `Phylogeny.js`, `RefBased.js`, `RunFaQCs.js`, `Taxonomy.js`) [[1]](diffhunk://#diff-bbe7a62f8f6d24087a576a90e706a6fec1e96a2f8150d560277a0a92f7cb775bL30-R38) [[2]](diffhunk://#diff-56dedd420b2cc3a314b670107ee8d26d4e3992b3e6d21d7c4910fffed51a5a34L30-R38) [[3]](diffhunk://#diff-63bcb6da08b56b7d9b0cb2461e95c06488252dd394e6eb697ee9de5b6993c87aL30-R38) [[4]](diffhunk://#diff-ac02c69f1c0ea9b6e24e74cb2fbd501eaed62ca60ede474c7c3b5da6404879c5L30-R36) [[5]](diffhunk://#diff-d05cc1b0a62190fe5221b30dd151a43177ceec0d8b38f831709f7263457ff6efL45-R51) [[6]](diffhunk://#diff-b7b78168e1b90bcef9bb3de0aa9dcdc73bbc6fd567a14a69160d2d5dc3f79e74L33-R41) [[7]](diffhunk://#diff-cd816a420b07c0b785657a48ef79f47bb19d21751e5976aa3c7cae77c46e4d60L107-R115) [[8]](diffhunk://#diff-7798fc2bd1f5116316655e57829c85310037ec1e6326212e59270b47d87a0755L30-R38) [[9]](diffhunk://#diff-8a7fe397191b05d073c233a7da99f4d6453af89a53a0b00e74028a745954c63eL138-R146)

These changes improve maintainability, make the codebase more extensible for future features, and ensure a consistent user experience across all metagenomics result views.