### PR TITLE
58 fix error on annotation and checkm filename duplicate issue

### DIFF
--- a/workflows/Nextflow/metagenomics/nextflow/modules/contigBinning/contigBinning.nf
+++ b/workflows/Nextflow/metagenomics/nextflow/modules/contigBinning/contigBinning.nf
@@ -33,9 +33,18 @@ process runBinning {
 process checkM {
     label 'binning'
     containerOptions { "--bind=${settings["checkMdb"]}:/venv/checkM --env \"CHECKM_DATA_PATH=/venv/checkM\"" }
+    publishDir(
+        path: { settings["binningOutDir"] },
+        mode: 'copy'
+    )
+
     input:
     val settings
     path binDir
+
+    output:
+    path "CheckM_log.txt"
+    path "${settings["projName"]}_checkM.summary"
 
     script:
     """

--- a/workflows/Nextflow/metagenomics/nextflow/modules/contigBinning/contigBinning.nf
+++ b/workflows/Nextflow/metagenomics/nextflow/modules/contigBinning/contigBinning.nf
@@ -35,7 +35,6 @@ process checkM {
     containerOptions { "--bind=${settings["checkMdb"]}:/venv/checkM --env \"CHECKM_DATA_PATH=/venv/checkM\"" }
     input:
     val settings
-    path summary
     path binDir
 
     script:
@@ -43,7 +42,7 @@ process checkM {
     checkm lineage_wf --tmpdir . -q --tab_table \
     -e 1e-10 \
     -l 0.7 \
-    -f $summary \
+    -f ${settings["projName"]}_checkM.summary \
     -t ${task.cpus} \
     -x fasta $binDir . 1>CheckM_log.txt 2>&1
     """
@@ -61,7 +60,7 @@ workflow BINNING {
     
     runBinning(settings, contigs, abundances)
     if(settings["doCheckM"]) {
-        checkM(settings, runBinning.out.binSummary, runBinning.out.binDir)
+        checkM(settings, runBinning.out.binDir)
     }
 
 }

--- a/workflows/Nextflow/metagenomics/nextflow/modules/runAnnotation/runAnnotation.nf
+++ b/workflows/Nextflow/metagenomics/nextflow/modules/runAnnotation/runAnnotation.nf
@@ -64,6 +64,8 @@ process prokkaAnnotate {
     def locustag = settings["projName"] == null ? "" : "--locustag ${settings["projName"]}"
     def prefix = settings["projName"] == null ? "" : "--prefix ${settings["projName"]}"
     def taxKingdom = kingdomValue.equalsIgnoreCase("metagenome") ? "--kingdom Bacteria --metagenome" : "--kingdom $kingdomValue"
+    def projLog = settings["projName"] == null ? "" : "${settings["projName"]}.log"
+    def appendProjLog = projLog == "" || projLog == "Annotation.log" ? "" : "cat ${projLog} >> Annotation.log"
 
     """
     $hmmPrep
@@ -80,7 +82,7 @@ process prokkaAnnotate {
     $taxKingdom \
     $contigs 2>>Annotation.log 
 
-    cat ${settings["projName"]}.log >> Annotation.log
+    $appendProjLog
     """
 }
 


### PR DESCRIPTION
This pull request updates the metagenomics Nextflow workflow to improve output handling and streamline process inputs/outputs for the `checkM` and `prokkaAnnotate` steps. The primary focus is on making output files more predictable and ensuring logs are managed more robustly.

**Improvements to the binning and quality check workflow:**

* The `checkM` process now publishes its output files (`CheckM_log.txt` and a summary file) directly to the configured output directory, making results easier to locate and manage.
* The `checkM` process no longer requires a separate summary file as input; instead, it generates the summary file itself, simplifying the workflow and reducing input dependencies. The workflow invocation of `checkM` was updated accordingly. [[1]](diffhunk://#diff-86a7cd2571bbfb6d871430515b80837d2b47d2b12d570042a6b057dc1221711eR36-R54) [[2]](diffhunk://#diff-86a7cd2571bbfb6d871430515b80837d2b47d2b12d570042a6b057dc1221711eL64-R72)

**Enhancements to annotation logging:**

* The `prokkaAnnotate` process now conditionally appends a project-specific log file to the main annotation log only if it is appropriate, avoiding redundant or empty log concatenation. This makes the logging behavior more robust and context-aware. [[1]](diffhunk://#diff-a67fc63710b24002fc4bb0bde258d7ffb207ec5033ce18327c33472050311534R67-R68) [[2]](diffhunk://#diff-a67fc63710b24002fc4bb0bde258d7ffb207ec5033ce18327c33472050311534L83-R85)